### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   test-and-analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maor224/trade-execution-service/security/code-scanning/1](https://github.com/maor224/trade-execution-service/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to a container registry.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
